### PR TITLE
fix(error): avoid override errors on rollback

### DIFF
--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -246,6 +246,8 @@ func Start(ctx context.Context, rt container.Runtime, ag agent.Agent, opts Optio
 
 	// rollback removes partially created containers on startup failure.
 	rollback := func() {
+		//nolint:govet // redeclare to avoid override of the outer scope
+		var err error
 		names := []string{agentName}
 		if proxyName != "" {
 			names = append(names, proxyName)


### PR DESCRIPTION
Redeclare `err` in the `rollback()` scope so that it does not override the outer scope.


#### Example

```go
if err != nil {
	rollback()
	return "", fmt.Errorf("start sidecar: %w", err)
}
```

```sh
# before
level=INFO msg="Error: start sidecar: %!w(<nil>)"

# after
level=INFO msg="Error: start sidecar: exit status 126"
```